### PR TITLE
(fix) progressbar now propagates correctly through calls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Progress bar
 ^^^^^^^^^^^^
 
 Whether to display a progress bar during file download.
-Defaults to `True`
+Defaults to `True`::
 
   path = download(url, file_path, progressbar=True)
   
@@ -65,7 +65,7 @@ Replace
 ^^^^^^^
 
 If `True` and the URL points to a single file, overwrite the old file if possible.
-Defaults to `False`.
+Defaults to `False`::
 
   path = download(url, file_path, replace=False)
   
@@ -73,7 +73,7 @@ Timeout
 ^^^^^^^
 
 The URL open timeout in seconds.
-Defaults to 10 seconds.
+Defaults to 10 seconds::
 
   path = download(url, file_path, timeout=10)
   
@@ -81,6 +81,6 @@ Verbose
 ^^^^^^^
 
 Whether to print download status to the screen.
-Defaults to `True`.
+Defaults to `True`::
 
   path = download(url, file_path, verbose=True)

--- a/README.rst
+++ b/README.rst
@@ -40,9 +40,47 @@ Download a file on the web is as easy as::
 
 a file called ``file_name`` will be downloaded to the folder of ``file_path``.
 
+File types
+^^^^^^^^^^
+
 If your file is a zip file, you can add the flag::
 
-  path = download(url, file_path, zipfile=True)
+  path = download(url, file_path, kind="zip")
 
 in this case, the file will be downloaded, and then unzipped into the folder
 specified by `file_name`.
+
+Supported formats are `'file', 'zip', 'tar', 'tar.gz'`
+Defaults to `file`.
+
+Progress bar
+^^^^^^^^^^^^
+
+Whether to display a progress bar during file download.
+Defaults to `True`
+
+  path = download(url, file_path, progressbar=True)
+  
+Replace
+^^^^^^^
+
+If `True` and the URL points to a single file, overwrite the old file if possible.
+Defaults to `False`.
+
+  path = download(url, file_path, replace=False)
+  
+Timeout
+^^^^^^^
+
+The URL open timeout in seconds.
+Defaults to 10 seconds.
+
+  path = download(url, file_path, timeout=10)
+  
+Verbose
+^^^^^^^
+
+Whether to print download status to the screen.
+Defaults to `True`.
+
+  path = download(url, file_path, verbose=True)

--- a/download/download.py
+++ b/download/download.py
@@ -89,7 +89,7 @@ def download(url, path, kind='file',
         path_temp = _TempDir()
         path_temp_file = op.join(path_temp, "tmp.{}".format(kind))
         _fetch_file(download_url, path_temp_file, timeout=timeout,
-                    verbose=verbose)
+                    verbose=verbose, progressbar=progressbar)
 
         # Unzip the file to the out path
         if verbose:
@@ -106,7 +106,7 @@ def download(url, path, kind='file',
     else:
         if not op.isdir(op.dirname(path)):
             os.makedirs(op.dirname(path))
-        _fetch_file(download_url, path, timeout=timeout, verbose=verbose)
+        _fetch_file(download_url, path, timeout=timeout, verbose=verbose, progressbar=progressbar)
         msg = 'Successfully downloaded file to {}'.format(path)
     if verbose:
         tqdm.write(msg)


### PR DESCRIPTION
Before this fix, the progressbar would always be shown even if `download(url, path, progressbar=False)` was called