### PR TITLE
verification of download size before rename

### DIFF
--- a/download/download.py
+++ b/download/download.py
@@ -260,7 +260,7 @@ def _fetch_file(
                     )
         local_file_size = get_file_size(temp_file_name)
         if local_file_size != remote_file_size:
-            raise Exception("Error: File size is %s and should be $s" % (local_file_size, remote_file_size))
+            raise Exception("Error: File size is %d and should be %d" % (local_file_size, remote_file_size))
         shutil.move(temp_file_name, file_name)
     except Exception as ee:
         raise RuntimeError(

--- a/download/download.py
+++ b/download/download.py
@@ -262,7 +262,9 @@ def _fetch_file(
         local_file_size = get_file_size(temp_file_name)
         if local_file_size != remote_file_size:
             if remote_file_size != remote_file_size_default:
-                raise Exception("Error: File size is %d and should be %d" % (local_file_size, remote_file_size))
+                raise Exception("Error: File size is %d and should be %d"
+                                "* Please wait some time and try re-downloading the file again."
+                                % (local_file_size, remote_file_size))
         shutil.move(temp_file_name, file_name)
     except Exception as ee:
         raise RuntimeError(

--- a/download/download.py
+++ b/download/download.py
@@ -25,7 +25,7 @@ ZIP_KINDS = ["tar", "zip", "tar.gz"]
 
 
 def download(
-    url, path, kind="file", progressbar=True, replace=False, timeout=10.0, verbose=True
+        url, path, kind="file", progressbar=True, replace=False, timeout=10.0, verbose=True
 ):
     """Download a URL.
 
@@ -148,13 +148,13 @@ def _convert_url_to_downloadable(url):
 
 
 def _fetch_file(
-    url,
-    file_name,
-    resume=True,
-    hash_=None,
-    timeout=10.0,
-    progressbar=True,
-    verbose=True,
+        url,
+        file_name,
+        resume=True,
+        hash_=None,
+        timeout=10.0,
+        progressbar=True,
+        verbose=True,
 ):
     """Load requested file, downloading it if needed or requested.
 
@@ -211,13 +211,13 @@ def _fetch_file(
             req = request_agent(url)
             u = urllib.request.urlopen(req, timeout=timeout)
             try:
-                file_size = int(u.headers.get("Content-Length", "1").strip())
+                remote_file_size = int(u.headers.get("Content-Length", "1").strip())
             finally:
                 u.close()
                 del u
             if verbose:
                 tqdm.write(
-                    "Downloading data from %s (%s)\n" % (url, sizeof_fmt(file_size)),
+                    "Downloading data from %s (%s)\n" % (url, sizeof_fmt(remote_file_size)),
                     file=sys.stdout,
                 )
 
@@ -225,18 +225,15 @@ def _fetch_file(
             if not os.path.exists(temp_file_name):
                 resume = False
             if resume:
-                with open(temp_file_name, "rb", buffering=0) as local_file:
-                    local_file.seek(0, 2)
-                    initial_size = local_file.tell()
-                del local_file
+                initial_size = get_file_size(temp_file_name)
             else:
                 initial_size = 0
             # This should never happen if our functions work properly
-            if initial_size > file_size:
+            if initial_size > remote_file_size:
                 raise RuntimeError(
                     "Local file (%s) is larger than remote "
                     "file (%s), cannot resume download"
-                    % (sizeof_fmt(initial_size), sizeof_fmt(file_size))
+                    % (sizeof_fmt(initial_size), sizeof_fmt(remote_file_size))
                 )
 
             scheme = urllib.parse.urlparse(url).scheme
@@ -245,7 +242,7 @@ def _fetch_file(
                 url,
                 temp_file_name,
                 initial_size,
-                file_size,
+                remote_file_size,
                 verbose,
                 progressbar,
                 ncols=80,
@@ -261,6 +258,9 @@ def _fetch_file(
                         "Hash mismatch for downloaded file %s, "
                         "expected %s but got %s" % (temp_file_name, hash_, md5)
                     )
+        local_file_size = get_file_size(temp_file_name)
+        if local_file_size != remote_file_size:
+            raise Exception("Error: File size is %s and should be $s" % (local_file_size, remote_file_size))
         shutil.move(temp_file_name, file_name)
     except Exception as ee:
         raise RuntimeError(
@@ -270,7 +270,7 @@ def _fetch_file(
 
 
 def _get_ftp(
-    url, temp_file_name, initial_size, file_size, verbose_bool, progressbar, ncols=80
+        url, temp_file_name, initial_size, file_size, verbose_bool, progressbar, ncols=80
 ):
     """Safely (resume a) download to a file from FTP."""
     # Adapted from: https://pypi.python.org/pypi/fileDownloader.py
@@ -321,7 +321,7 @@ def _get_ftp(
 
 
 def _get_http(
-    url, temp_file_name, initial_size, file_size, verbose_bool, progressbar, ncols=80
+        url, temp_file_name, initial_size, file_size, verbose_bool, progressbar, ncols=80
 ):
     """Safely (resume a) download to a file from http(s)."""
     # Actually do the reading
@@ -478,3 +478,11 @@ def request_agent(url):
         },
     )
     return req
+
+
+def get_file_size(file_name):
+    with open(file_name, "rb", buffering=0) as local_file:
+        local_file.seek(0, 2)  # move the cursor to the end of the file
+        local_file_size = local_file.tell()
+    del local_file
+    return local_file_size


### PR DESCRIPTION
* PR: Making one final verification of the download file size before rename (removing the ".part").
* Motivation: Sometimes the python API will just finish the download like it has been completed when it isn't.

Sorry about the indentation changes (is the PyCharm, I think it's trying to create a visual differentiation of the parameter and the content of the method).