### PR TITLE
Fix github downloading

### DIFF
--- a/download/download.py
+++ b/download/download.py
@@ -142,9 +142,6 @@ def _convert_url_to_downloadable(url):
             out = url + "?dl=1"
         else:
             out = url.replace("dl=0", "dl=1")
-    elif "github.com" in url:
-        out = url.replace("github.com", "raw.githubusercontent.com")
-        out = out.replace("blob/", "")
     else:
         out = url
     return out


### PR DESCRIPTION
I am not sure how this should be actually working.

In this code:
```
from download import download
url = "http://github.com/salesforce/WikiSQL/raw/master/data.tar.bz2"
path = "data.tar.bz2"
chunk_size = 8192
download(url, path, progressbar=True, timeout=100)
```
I've got an exact URL and don't want it to be changed. I don't think you need to do anything with it.

Actually I think that function `_convert_url_to_downloadable(url)` should be removed. I don't think it's you problem to convert url to some formats.